### PR TITLE
TSO-4 Update <iframe> element in compare.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tsoo-html.code-workspace

--- a/compare.html
+++ b/compare.html
@@ -18,6 +18,9 @@
     <!-- Favicon -->
     <link rel="shortcut icon" href="./images/favicon.ico" type="image/x-icon">
 
+    <!-- CSS -->
+    <!-- All <iframe> frameborder should be in the external CSS -->
+
     <title>Compare | The Science of Obsidian</title>
 </head>
 <body>
@@ -160,13 +163,7 @@
 
             <figure>
 
-                <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NSIhZlqfVeU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-
-                    <p>
-                        You can watch the video <a href="https://www.youtube-nocookie.com/embed/NSIhZlqfVeU">here</a> instead.
-                    </p>
-    
-                </iframe>
+                <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/NSIhZlqfVeU" title="A YouTube video of comparing Obsidian with Evernote" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                 <figcaption>
                     Comparing Obsidian with Evernote
                 </figcaption>


### PR DESCRIPTION
Remove any text or markup inside the `<iframe>` element as its content model is "_nothing_." Remove `frameborder` attribute of `<iframe>` as it is deprecated and should be set in CSS instead. Update the `title` attribute of the `<iframe>` element for accessibility purposes.

Add a comment in the `<head>` element to set a reminder for `frameborder` in CSS.